### PR TITLE
fix(idp/client): 配置vite开发服务器的主机和允许访问域名

### DIFF
--- a/apps/idp/client/vite.config.ts
+++ b/apps/idp/client/vite.config.ts
@@ -18,7 +18,9 @@ export default defineConfig(({ command }) => {
     return {
       ...common,
       server: {
+        host: '127.0.0.1',
         port: requireIntEnv('CSISP_IDP_CLIENT_PORT'),
+        allowedHosts: ['csisp-idp-client.vercel.app'],
         proxy: {
           '/api/idp': {
             target: requireEnv('CSISP_IDP_URL'),


### PR DESCRIPTION
添加开发服务器的主机配置和允许访问的域名，确保开发环境能正确代理请求